### PR TITLE
フラッシュメッセージの設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,36 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
+  <% if notice %>
+  <div class="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 mb-4 rounded shadow-sm" role="alert">
+    <div class="flex">
+      <div class="py-1">
+        <svg class="w-6 h-6 mr-4 text-green-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <div>
+        <p class="font-medium"><%= notice %></p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<% if alert %>
+  <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded shadow-sm" role="alert">
+    <div class="flex">
+      <div class="py-1">
+        <svg class="w-6 h-6 mr-4 text-red-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <div>
+        <p class="font-medium"><%= alert %></p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
   <body>
     <%= yield %>
   </body>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,19 @@
+<% if resource&.errors.any? %>
+  <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 rounded shadow-sm" role="alert">
+    <div class="flex">
+      <div class="py-1">
+        <svg class="w-6 h-6 mr-4 text-red-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      </div>
+      <div>
+        <p class="font-bold">以下の<%= resource.errors.count %>件のエラーが発生しました</p>
+        <ul class="list-disc pl-5">
+          <% resource.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
Tailwind CSSを活用して、フラッシュメッセージとフォームエラー表示機能を実装

## 変更内容
1. アプリケーション全体で使用するフラッシュメッセージ（notice/alert）のスタイリングを追加
2. フォームエラーメッセージ用のSharedファイルを作成

## 実装詳細
- **フラッシュメッセージ**: ヘッダーとメインコンテンツの間に配置
  - 成功メッセージ（notice）: 緑色のスタイリング
  - 警告メッセージ（alert）: 赤色のスタイリング

- **エラーメッセージ**: フォームのバリデーションエラー表示用
  - `app/views/shared/_error_messages.html.erb`に実装
  - エラーの総数とエラーメッセージのリストを表示

## 使用方法
1. フラッシュメッセージは自動的にアプリケーション内で表示
2. エラーメッセージパーシャルは以下のように使用:
   ```erb
   <%= render 'shared/error_messages', resource: @user %>
   ```
