### PR TITLE
usernameカラムの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  private
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :username, presence: true
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
+  <%= f.label :username %><br />
+  <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -21,6 +21,7 @@
           </svg>
           <span>投稿をみる</span>
         </div>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: false } %>
       </div>
     </div>
   </div>

--- a/db/migrate/20250321035506_add_username_to_users.rb
+++ b/db/migrate/20250321035506_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_20_014305) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_21_035506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_014305) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
- Deviseを使用したユーザー認証システムに「ユーザー名」機能を追加
- Postに登録したユーザー名を表示できるようにする

## 変更内容
1. ユーザーテーブルに `username` カラムを追加するマイグレーション
2. User モデルにユーザー名の検証ルールを追加
3. 登録フォームにユーザー名フィールドを追加
4. Devise パラメーターにユーザー名を許可するよう設定

## 技術的詳細
- **マイグレーション**: `AddUsernameToUsers` マイグレーションを作成し、users テーブルに username カラム（string型）を追加
- ユーザー名が必須であることを検証するバリデーションを追加 (`validates :username, presence: true`)
- **コントローラーの設定**: Devise のストロングパラメーターに username を追加することで、サインアップ時にユーザー名の登録を許可
- サインアップフォームにユーザー名入力フィールドを追加
