### PR TITLE
今日の一問機能の実装

### DIFF
--- a/app/controllers/daily_questions_controller.rb
+++ b/app/controllers/daily_questions_controller.rb
@@ -1,0 +1,11 @@
+class DailyQuestionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @daily_questions = DailyQuestion.includes(post: :user).order(created_at: :desc)
+  end
+
+  def show
+    @daily_question = DailyQuestion.includes(post: :user).find(params[:id])
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,6 +7,7 @@ class PostsController < ApplicationController
 
     def new
         @post = Post.new
+        @post.build_daily_question
     end
 
     def create
@@ -22,6 +23,7 @@ class PostsController < ApplicationController
     private
 
     def post_params
-      params.require(:post).permit(:title, :body, :learning_date)
-    end
+        params.require(:post).permit(:title, :body, :learning_date,
+        daily_question_attributes: [:body, :question_answer])
+      end
 end

--- a/app/helpers/daily_questions_helper.rb
+++ b/app/helpers/daily_questions_helper.rb
@@ -1,0 +1,2 @@
+module DailyQuestionsHelper
+end

--- a/app/models/daily_question.rb
+++ b/app/models/daily_question.rb
@@ -1,0 +1,6 @@
+class DailyQuestion < ApplicationRecord
+  belongs_to :post
+  
+  validates :body, presence: true, length: { maximum: 400 }
+  validates :question_answer, presence: true, length: { maximum: 400 }
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,9 @@
 class Post < ApplicationRecord
+    belongs_to :user
+    has_one :daily_question, dependent: :destroy
+    accepts_nested_attributes_for :daily_question
+
     validates :title, presence: true, length: { maximum: 20 }
     validates :body, presence: true, length: { maximum: 400 }
     validates :learning_date, presence: true
-  
-    belongs_to :user
 end

--- a/app/views/daily_questions/index.html.erb
+++ b/app/views/daily_questions/index.html.erb
@@ -1,0 +1,25 @@
+<div class="container mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-6">今日の一問に挑戦</h1>
+  
+  <div class="grid gap-6">
+    <% @daily_questions.each do |question| %>
+      <div class="bg-white rounded-lg shadow-md p-6">
+        <div class="flex items-center mb-4">
+          <div class="text-gray-500 mr-4">
+            <%= question.post.user.username %>
+            <%= l(question.post.created_at.to_date, format: :short) %>
+          </div>
+        </div>
+
+        <h3 class="text-xl font-semibold mt-3 mb-2">
+          <%= link_to question.post.title, daily_question_path(question), class: "text-blue-600 hover:text-blue-800" %>
+        </h3>
+
+        
+        <div>
+          <p><%= question.body %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/daily_questions/show.html.erb
+++ b/app/views/daily_questions/show.html.erb
@@ -1,0 +1,37 @@
+<div class="max-w-2xl mx-auto my-8 px-4">
+  <div class="bg-white rounded-lg shadow p-6">
+    <div class="flex items-center mb-4">
+      <div>
+        <p class="text-gray-700"><%= @daily_question.post.user.username %></p>
+        <p class="text-xs text-gray-500"><%= @daily_question.post.learning_date %></p>
+      </div>
+    </div>
+
+    <h2 class="text-2xl font-bold mb-4"><%= @daily_question.post.title %></h2>
+    
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold mb-2">問題</h3>
+      <div class="p-4 bg-gray-50 rounded-md">
+        <p><%= @daily_question.body %></p>
+      </div>
+    </div>
+
+    <div class="mb-6">
+      <h3 class="text-lg font-semibold mb-2">解答</h3>
+      <textarea class="w-full p-3 border rounded-md" rows="4" placeholder="ここに解答を入力"></textarea>
+    </div>
+
+    <div data-controller="toggle">
+      <button data-action="click->toggle#toggle" class="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
+        解答を表示
+      </button>
+      <div data-toggle-target="content" class="hidden mt-4 p-4 bg-blue-50 rounded-md">
+        <p><%= @daily_question.question_answer %></p>
+      </div>
+    </div>
+
+    <div class="mt-8 text-center">
+      <%= link_to "一覧に戻る", daily_questions_path, class: "bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600" %>
+    </div>
+  </div>
+</div>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -23,7 +23,9 @@
             <span>投稿をみる</span>
           </div>
         <% end %>
-
+        
+       <li><%= link_to '学びの記録一覧', posts_path %></li>
+        <li><%= link_to '今日の一問に挑戦', daily_questions_path %></li>
         <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: false } %>
     </div>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -18,6 +18,22 @@
         <%= f.text_area :body, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500', rows: '10' %>
       </div>
 
+      <div class="mt-8 mb-4">
+          <h2 class="text-xl font-bold mb-4">今日の一問</h2>
+          
+          <%= f.fields_for :daily_question do |question_form| %>
+            <div class="mb-4">
+              <%= question_form.label :body, class: "block mb-2" %>
+              <%= question_form.text_area :body, rows: 6, class: "w-full p-2 border rounded", placeholder: "次のうち、正しいのはどれ？\nA)○○\nB)○○\nC)○○" %>
+            </div>
+          
+            <div class="mb-4">
+              <%= question_form.label :question_answer, class: "block mb-2" %>
+              <%= question_form.text_field :question_answer, class: "w-full p-2 border rounded", placeholder: "A" %>
+            </div>
+          <% end %>
+        </div>
+
       <div>
         <%= f.submit class: "px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400" %>
       </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,6 +9,10 @@ ja:
         title: タイトル
         body: 学習内容
         learning_date: 学習日
+        daily_question: 今日の一問
+      daily_question:
+        body: 問題
+        question_answer: 解答
       profile:
         username: ユーザー名
         bio: 自己紹介

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,3 +25,7 @@ ja:
     create:
       success: 学びの振り返りを作成しました！
       failure: 投稿できませんでした
+
+  daily_question:
+    show: 
+      question:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
+  get "daily_questions/show"
   devise_for :users, controllers: {
     registrations: "users/registrations",
     sessions: "users/sessions"
   }
   resources :posts, only: %i[index new create]
+  resources :daily_questions, only: [ :index, :show ]
 
   get "homes/top"
   root "home#top"

--- a/db/migrate/20250321072525_create_daily_questions.rb
+++ b/db/migrate/20250321072525_create_daily_questions.rb
@@ -1,0 +1,11 @@
+class CreateDailyQuestions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :daily_questions do |t|
+      t.text :body
+      t.text :question_answer
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_21_052817) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_21_072525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "daily_questions", force: :cascade do |t|
+    t.text "body"
+    t.text "question_answer"
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_daily_questions_on_post_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
@@ -37,5 +46,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_052817) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "daily_questions", "posts"
   add_foreign_key "posts", "users"
 end

--- a/test/controllers/daily_questions_controller_test.rb
+++ b/test/controllers/daily_questions_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DailyQuestionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get daily_questions_show_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/daily_questions.yml
+++ b/test/fixtures/daily_questions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  body: MyText
+  question_answer: MyText
+  post: one
+
+two:
+  body: MyText
+  question_answer: MyText
+  post: two

--- a/test/models/daily_question_test.rb
+++ b/test/models/daily_question_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DailyQuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
学習記録に関連付けた「今日の一問」機能を実装。ユーザーが学習内容に基づいた問題と解答を作成・共有できる。

## 変更内容
1. DailyQuestion モデルの新規作成
2. 学習記録（Post）と今日の一問の関連付け
3. 今日の一問の一覧表示・詳細表示機能
4. 新規投稿フォームに今日の一問入力セクションを追加

## データモデル設計
- `daily_questions` テーブルを作成：
  - `body`: 問題文（テキスト）
  - `question_answer`: 解答（テキスト）
  - `post_id`: 関連する学習記録（外部キー）

### モデル間の関連
- Post モデルと DailyQuestion モデルの 1対1 関連付け
- nested attributes による関連データの保存

## コントローラー実装
- `DailyQuestionsController` の実装：
  - `index`: 一問一覧の表示
  - `show`: 一問詳細（問題と解答）の表示
- `PostsController` の機能拡張：
  - 投稿作成時に今日の一問のデータも保存
  - ストロングパラメーター修正

## ビュー実装
- 一覧ページ（index）：
  - タイトル、投稿者、問題文を表示
  - 詳細へのリンク
- 詳細ページ（show）：
  - 問題文と解答の表示
- 投稿フォーム（new）：
  - 学習記録入力欄に加えて今日の一問の問題入力フォームを追加

## ルーティング
- `resources :daily_questions, only: [:index, :show]` の追加
