### PR TITLE
ハンバーガーメニューの実装

### DIFF
--- a/app/javascript/controllers/hamburger_controller.js
+++ b/app/javascript/controllers/hamburger_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["name", "output", "menu"]
+
+  connect() {
+    console.log("hamburger controller connected!")
+    if (this.hasMenuTarget) {
+      this.menuTarget.classList.add("hidden")
+    }
+  }
+  
+  toggleMenu() {
+    this.menuTarget.classList.toggle("hidden")
+  }
+}

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["name", "output"]
+
   connect() {
-    this.element.textContent = "Hello World!"
+    console.log("Hello controller connected!")
+  }
+
+  greet() {
+    this.outputTarget.textContent = `こんにちは、${this.nameTarget.value}さん!`
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import HamburgerController from "./hamburger_controller"
+application.register("hamburger", HamburgerController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,5 +13,22 @@
         <% end %>
       </h1>
     </div>
-  </div>
+
+<!-- ハンバーガーメニュー部分 -->
+<div class="relative">
+  <button data-action="click->hamburger#toggleMenu" class="focus:outline-none">
+    <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+  </button>
+
+  <div data-hamburger-target="menu" class="absolute right-0 mt-2 bg-white border rounded shadow-lg p-2 w-32 text-black">
+  <ul>
+    <li><%= link_to '学びの記録一覧', posts_path %></li>
+    <li><%= link_to '今日の一問に挑戦', daily_questions_path %></li>
+    <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %></li>
+  </ul>
+</div>
+</div>
+</div>
 </header>


### PR DESCRIPTION
## 概要
ヘッダーに、クリックで表示/非表示を切り替えられるハンバーガーメニューを実装

## 技術的詳細

### Stimulus コントローラーの実装
- `hamburger_controller.js` を新規作成
- `toggleMenu()` メソッドでメニューの表示/非表示を切り替え
- `connect()` メソッドで初期状態（非表示）を設定

### ヘッダーコンポーネントの拡張
- ハンバーガーアイコンのボタンを追加
- ドロップダウンメニューに下記のページのリンクを設置
  - 学びの記録一覧
  - 今日の一問に挑戦
  - ログアウト

### JavaScript コントローラーの登録
- `controllers/index.js` に `HamburgerController` を登録
