### PR TITLE
ActiveStrageの導入

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,7 +51,7 @@ class PostsController < ApplicationController
     private
 
     def post_params
-        params.require(:post).permit(:title, :body, :learning_date,
+        params.require(:post).permit(:title, :body, :learning_date, :image, 
         daily_question_attributes: [ :body, :question_answer ])
       end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,9 +1,19 @@
 class Post < ApplicationRecord
     belongs_to :user
     has_one :daily_question, dependent: :destroy
+    has_one_attached :image
     accepts_nested_attributes_for :daily_question
 
     validates :title, presence: true, length: { maximum: 20 }
     validates :body, presence: true, length: { maximum: 400 }
     validates :learning_date, presence: true
+
+    private
+  
+    def image_type_validation
+      if image.attached? && !image.content_type.in?(%w(image/jpeg image/png image))
+        errors.add(:image, 'はJPEG、PNGでアップロードしてください')
+      end
+    end
+
 end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -41,6 +41,17 @@
         </div>
       </div>
 
+      <div class="mb-4">
+        <%= f.label :image, "画像", class: "block text-gray-700 text-sm font-bold mb-2" %>
+        <%= f.file_field :image, class: "w-full", accept: "image/jpeg,image/png,image/gif" %>
+        <% if f.object.image.attached? %>
+          <div class="mt-2">
+            <p class="text-sm text-gray-500">現在の画像:</p>
+            <%= image_tag f.object.image.variant(resize_to_limit: [300, 200]), class: "mt-1 rounded" %>
+          </div>
+        <% end %>
+      </div>
+
       <div class="mt-8 mb-4">
         <h2 class="text-xl font-bold mb-4">今日の一問</h2>
         

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -41,6 +41,17 @@
         </div>
       </div>
 
+      <div class="mb-4">
+        <%= f.label :image, "画像", class: "block text-gray-700 text-sm font-bold mb-2" %>
+        <%= f.file_field :image, class: "w-full", accept: "image/jpeg,image/png,image/gif" %>
+        <% if f.object.image.attached? %>
+          <div class="mt-2">
+            <p class="text-sm text-gray-500">現在の画像:</p>
+            <%= image_tag f.object.image.variant(resize_to_limit: [300, 200]), class: "mt-1 rounded" %>
+          </div>
+        <% end %>
+      </div>
+
       <div class="mt-8 mb-4">
         <h2 class="text-xl font-bold mb-4">今日の一問</h2>
         

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -17,6 +17,13 @@
   <div class="whitespace-pre-wrap text-gray-700"><%= @post.body %></div>
 </div>
 
+<% if @post.image.attached? %>
+  <div class="my-4">
+    <%= image_tag @post.image, class: "rounded-lg mx-auto" %>
+  </div>
+<% else %>
+<% end %>
+
 <!-- 今日の一問 -->
 <div class="mt-8">
   <h3 class="text-lg font-bold mb-2">今日の一問</h3>

--- a/db/migrate/20250322144141_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20250322144141_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_22_130836) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_22_144141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "daily_questions", force: :cascade do |t|
     t.text "body"
@@ -47,6 +75,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_22_130836) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "daily_questions", "posts"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## 概要
学習記録に画像を添付できる機能を実装

## 変更内容
1. ActiveStorage の導入
2. 投稿モデルに画像添付機能を追加
3. 投稿フォームに画像アップロード機能を実装
4. 詳細表示画面での画像表示対応

## ActiveStorage の設定
- ActiveStorage のマイグレーションを実行し、必要なテーブルを作成

## モデル
- Post モデルに `has_one_attached :image` を追加
- 画像タイプをJPEG/PNG形式に制限

## Postコントローラー
- ストロングパラメーターに `:image` を追加し、画像データの受け取りを許可

## ビュー
- 新規投稿フォーム・編集フォームに画像アップロード欄を追加
- 既存の画像がある場合、編集フォームに表示（予定）
- 詳細ページで添付画像を表示
