### PR TITLE
サインイン画面・サインアップ画面の調整

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,34 +1,37 @@
-<h2>Sign up</h2>
+<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md mt-8">
+  <%= content_tag :h2, t('.title'), class: "text-2xl font-bold mb-6 text-center text-gray-800" %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-  <%= f.label :username %><br />
-  <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+    <div class="mb-4">
+      <%= f.label :username, class: "block text-gray-700 font-medium mb-2" %>
+      <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500", placeholder: "ユーザー名" %>
+    </div>
+
+    <div class="mb-4">
+      <%= f.label :email, class: "block text-gray-700 font-medium mb-2" %>
+      <%= f.email_field :email, autocomplete: "email", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500" , placeholder: "abcdefg@betterthan.com" %>
+    </div>
+
+    <div class="mb-4">
+      <%= f.label :password, class: "block text-gray-700 font-medium mb-2" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500", placeholder: @minimum_password_length && "#{@minimum_password_length}文字以上の英数字を入力" %>
+    </div>
+  
+  
+
+    <div class="mb-6">
+      <%= f.label :password_confirmation, class: "block text-gray-700 font-medium mb-2" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500p",  placeholder: "パスワードを再度入力" %>
+    </div>
+
+    <div class="mb-6">
+      <%= f.submit t('.sign_up'), class: "w-full bg-[#FF9800] text-white py-3 px-4 rounded-md shadow hover:bg-[#F57C00] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF9800] transition-colors" %>
+    </div>
+  <% end %>
+
+  <div class="text-center mt-4 mb-4">
+    <%= link_to t('.to_sign_in'), new_session_path(resource_name), class: "text-sm text-gray-700 hover:text-sky-700" %>
   </div>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,25 @@
-<h2>Log in</h2>
+<div class="max-w-md mx-auto bg-white p-8 rounded-lg shadow-md mt-8">
+  <%= content_tag :h2, t('.title'), class: "text-2xl font-bold mb-6 text-center text-gray-800" %>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+    <div class="mb-4">
+      <%= f.label :email, class: "block text-gray-700 font-medium mb-2" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500", placeholder: "abcdefg@betterthan.com" %>
+    </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+    <div class="mb-4">
+      <%= f.label :password, class: "block text-gray-700 font-medium mb-2" %>
+      <%= f.password_field :password, autocomplete: "current-password", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500", placeholder: "パスワードを入力" %>
+    </div>
+
+    <div class="mb-6">
+      <%= f.submit t('.sign_in'), class: "w-full bg-[#FF9800] text-white py-3 px-4 rounded-md shadow hover:bg-[#F57C00] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#FF9800] transition-colors" %>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
+  <div class="text-center mt-4 mb-4">
+    <%= link_to t('.to_sign_up'), new_registration_path(resource_name), class: "text-sm text-gray-700 hover:text-sky-700" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -23,10 +23,6 @@
             <span>投稿をみる</span>
           </div>
         <% end %>
-        
-       <li><%= link_to '学びの記録一覧', posts_path %></li>
-        <li><%= link_to '今日の一問に挑戦', daily_questions_path %></li>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo: false } %>
     </div>
   </div>
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -107,6 +107,7 @@ ja:
         title: 新規登録
         sign_up: アカウント作成
         username: ユーザー名
+        to_sign_in: ログイン画面へ
 
       signed_up: アカウント作成が完了しました！
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
@@ -120,6 +121,7 @@ ja:
       new:
         title: ログイン
         sign_in: ログイン
+        to_sign_up: 新規登録画面へ
       signed_in: ログインしました
       signed_out: ログアウトしました
     shared:


### PR DESCRIPTION
## 概要
サインアップ、サインイン画面のデザインを修正

## 変更の詳細
- 入力フィールドにplaceholderを追加
- 送信ボタンをアプリのイメージカラーに変更
- 画面遷移をわかりやすくする補助リンクを追加

### i18n対応の拡充
- 「新規登録画面へ」「ログイン画面へ」を翻訳キーとして追加
