### PR TITLE
AWS S3の環境設定

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon 
+  config.active_storage.replace_on_assign_to_many = false
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,6 +1,13 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
 amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
   region: ap-northeast-1
-  bucket: bty-storage.202503242348
+  bucket: bty-storage-20250325 
+  public: true  # これを追加
+  http_open_timeout: 60  # これを追加
+  http_read_timeout: 60 


### PR DESCRIPTION
## 概要
AWS S3の設定を追加・修正

### 変更内容
1. **`config/environments/development.rb`**
    - `config.active_storage.service` を `:amazon` に設定
    - `config.active_storage.replace_on_assign_to_many = false` を追加

2. **`config/storage.yml`**。
      - `bucket` 名を `bty-storage-20250325` に変更
      - `public: true` を追加
      - `http_open_timeout: 60` を追加
      - `http_read_timeout: 60` を追加
