### PR TITLE
Usernameのバリデーションの追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  validates :username, presence: true, length: { maximum: 10 }
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 

--- a/app/views/daily_questions/index.html.erb
+++ b/app/views/daily_questions/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto p-6">
-  <h1 class="text-2xl font-bold mb-6">今日の一問に挑戦</h1>
+  <h1 class="text-2xl font-bold mb-6"><%= t('.title') %></h1>
   
   <div class="grid gap-6">
     <% @daily_questions.each do |question| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,7 @@
 
     <div class="mb-4">
       <%= f.label :username, class: "block text-gray-700 font-medium mb-2" %>
-      <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500", placeholder: "ユーザー名" %>
+      <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500", placeholder: "10文字以内のユーザー名" %>
     </div>
 
     <div class="mb-4">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mx-auto p-6 max-w-4xl">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold">学びの記録</h1>
+    <h1 class="text-2xl font-bold"><%= t("title") %></h1>
     <% if user_signed_in? %>
       <%= link_to "新規投稿", new_post_path, class: "bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg shadow-sm transition duration-150 ease-in-out" %>
     <% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -149,4 +149,4 @@ ja:
       not_found: は見つかりませんでした。
       not_locked: はロックされていません。
       not_saved:
-        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+        other: "%{count} 件のエラーが発生したため、アカウント作成ができませんでした"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -34,7 +34,9 @@ ja:
     destroy:
       success: 学びの振り返りが削除されました
 
-  daily_question:
+  daily_questions:
+    index:
+      title: 学びの振り返り作成
     show: 
       question:
 


### PR DESCRIPTION
## 概要
ユーザー名のバリデーションと文字数制限を追加

## ユーザー名バリデーション
* `User` モデルに以下のバリデーションを追加:
  * usernameの最大長を10文字に制限
  * 必須入力の検証

## フォーム表示の改善
* 新規登録画面のユーザー名入力欄のプレースホルダーを
  * 「ユーザー名」→「10文字以内のユーザー名」に変更

## 国際化（i18n）の強化
* 「今日の一問」ページのタイトルを翻訳キーに変更
* 「学びの記録」ページのタイトルを翻訳キーに変更
* エラーメッセージの日本語表現をより自然な形に修正:
  * 「%{resource} は保存されませんでした」→「アカウント作成ができませんでした」

