### PR TITLE
トグル機能の実装とi18nの調整

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,6 @@ application.register("hello", HelloController)
 
 import ImagePreviewController from "./image_preview_controller"
 application.register("image-preview", ImagePreviewController)
+
+import ToggleController from "./toggle_controller"
+application.register("toggle", ToggleController)

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["content"]
+
+  toggle() {
+    this.contentTarget.classList.toggle("hidden")
+  }
+}

--- a/app/views/daily_questions/show.html.erb
+++ b/app/views/daily_questions/show.html.erb
@@ -14,14 +14,14 @@
     </div>
     
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-2">問題</h3>
+      <h3 class="text-lg font-semibold mb-2"><%= t('.question') %></h3>
       <div class="p-4 bg-gray-50 rounded-md">
         <p><%= @daily_question.body %></p>
       </div>
     </div>
 
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-2">解答</h3>
+      <h3 class="text-lg font-semibold mb-2"><%= t('.question_answer') %></h3>
       <textarea class="w-full p-3 border rounded-md" rows="4" placeholder="ここに解答を入力"></textarea>
     </div>
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container mx-auto p-6 max-w-4xl">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-2xl font-bold"><%= t("title") %></h1>
+    <h1 class="text-2xl font-bold"><%= t('.title')%></h1>
     <% if user_signed_in? %>
       <%= link_to "新規投稿", new_post_path, class: "bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg shadow-sm transition duration-150 ease-in-out" %>
     <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -10,7 +10,7 @@
     </div>
   </div>
   
-  <h2 class="text-lg font-semibold mb-4 pb-2">自分の学びの振り返り</h2>
+  <h2 class="text-lg font-semibold mb-4 pb-2"><%= t('.title')%></h2>
   
   <div class="grid gap-6">
     <% if @posts.any? %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
 
   <div data-hamburger-target="menu" class="absolute right-0 mt-2 bg-white border rounded shadow-lg p-2 w-32 text-black">
   <ul>
-    <li><%= link_to '学びの記録一覧', posts_path %></li>
+    <li><%= link_to '学びの振り返り一覧', posts_path %></li>
     <li><%= link_to '今日の一問に挑戦', daily_questions_path %></li>
     <li><%= link_to 'マイページ', profile_path %></li>
     <li><%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -19,7 +19,7 @@ ja:
  
   posts:
     index:
-      title: 投稿一覧
+      title: 学びの振り返り
     new:
       title: 学びの振り返り作成
     create:
@@ -36,11 +36,14 @@ ja:
 
   daily_questions:
     index:
-      title: 学びの振り返り作成
+      title: 今日の一問
     show: 
-      question:
+      question: 問題
+      question_answer: 解答
 
   profiles:
+    show: 
+      title: 自分の学びの振り返り
     edit:
       username: ユーザー名
       bio: 自己紹介


### PR DESCRIPTION
## 概要
Stimulusを使用したトグル機能を実装し、アプリケーション全体のi18nを調整

## 主な変更内容
1. Stimulus ToggleControllerの新規作成
2. 各ページの翻訳キーを統一的に整備
3. ヘッダーとナビゲーションの表示テキスト修正

### トグル機能の実装
* `ToggleController`（Stimulus）を新規作成:
  * 要素の表示/非表示を切り替える機能を提供
  * `toggle()`メソッドで対象要素のhiddenクラスを切り替え

### i18n
* 各ビューの翻訳キーを統一的に整備:
  * 「学びの振り返り」のタイトル修正（t('.title')形式に統一）
  * 「今日の一問」ページの問題・解答表示に翻訳キーを適用
  * プロフィールページのタイトル調整

### ナビゲーション表示の改善
* ヘッダーメニューの表示テキストを修正:
  * 「学びの記録一覧」→「学びの振り返り一覧」に統一

### 翻訳ファイルの整備
* `config/locales/views/ja.yml` に以下の項目を追加:
  * 「今日の一問」の問題・解答関連の翻訳キー
