### PR TITLE
Following

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,13 +24,12 @@ class PostsController < ApplicationController
 
     def show
         @daily_question = @post.daily_question
+        @user = @post.user  # 投稿の作者を @user に設定
     end
-
 
     def edit
         @daily_question = @post.daily_question
     end
-
 
     def update
         if @post.update(post_params)

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,22 +1,22 @@
 class RelationshipsController < ApplicationController
     before_action :authenticate_user!
-  
+
     def create
       @user = User.find(params[:followed_id])
       current_user.follow(@user)
-      
+
       respond_to do |format|
         format.html { redirect_back(fallback_location: root_path) }
         format.turbo_stream
       end
     end
-  
+
     def destroy
         @user = User.find_by(id: params[:followed_id])
-      
+
         if @user
           relationship = current_user.active_relationships.find_by(followed_id: @user.id)
-      
+
           if relationship
             relationship.destroy
           else
@@ -25,11 +25,10 @@ class RelationshipsController < ApplicationController
         else
           redirect_back(fallback_location: root_path, alert: "ユーザーが見つかりませんでした") and return
         end
-      
+
         respond_to do |format|
           format.html { redirect_back(fallback_location: root_path) }
           format.turbo_stream
         end
       end
-      
-  end
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,35 @@
+class RelationshipsController < ApplicationController
+    before_action :authenticate_user!
+  
+    def create
+      @user = User.find(params[:followed_id])
+      current_user.follow(@user)
+      
+      respond_to do |format|
+        format.html { redirect_back(fallback_location: root_path) }
+        format.turbo_stream
+      end
+    end
+  
+    def destroy
+        @user = User.find_by(id: params[:followed_id])
+      
+        if @user
+          relationship = current_user.active_relationships.find_by(followed_id: @user.id)
+      
+          if relationship
+            relationship.destroy
+          else
+            redirect_back(fallback_location: root_path, alert: "フォロー関係が見つかりませんでした") and return
+          end
+        else
+          redirect_back(fallback_location: root_path, alert: "ユーザーが見つかりませんでした") and return
+        end
+      
+        respond_to do |format|
+          format.html { redirect_back(fallback_location: root_path) }
+          format.turbo_stream
+        end
+      end
+      
+  end

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,16 +1,16 @@
 class Relationship < ApplicationRecord
-    belongs_to :follower, class_name: 'User'
-    belongs_to :followed, class_name: 'User'
-  
+    belongs_to :follower, class_name: "User"
+    belongs_to :followed, class_name: "User"
+
     validates :follower_id, presence: true
     validates :followed_id, presence: true
     validate :not_self_follow
-    
+
     private
-    
+
     def not_self_follow
       if follower_id == followed_id
         errors.add(:followed_id, :not_self_follow)
       end
     end
-  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,16 @@
+class Relationship < ApplicationRecord
+    belongs_to :follower, class_name: 'User'
+    belongs_to :followed, class_name: 'User'
+  
+    validates :follower_id, presence: true
+    validates :followed_id, presence: true
+    validate :not_self_follow
+    
+    private
+    
+    def not_self_follow
+      if follower_id == followed_id
+        errors.add(:followed_id, :not_self_follow)
+      end
+    end
+  end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,18 @@ class User < ApplicationRecord
   has_many :answers, dependent: :destroy
   has_one :answer_record, dependent: :destroy
 
+  has_many :active_relationships, 
+    class_name: 'Relationship',
+    foreign_key: 'follower_id',
+    dependent: :destroy
+  has_many :passive_relationships, 
+    class_name: "Relationship",
+    foreign_key: "followed_id",
+    dependent: :destroy
+  
+  has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
+
   def like(post)
     liked_posts << post unless like?(post)
   end
@@ -59,6 +71,21 @@ class User < ApplicationRecord
     end
   end
 
+  def follow(other_user)
+    return if self == other_user # 自分自身はフォローできない
+    active_relationships.find_or_create_by(followed_id: other_user.id)
+  end
+
+  def unfollow(other_user)
+    relationship = active_relationships.find_by(followed_id: other_user.id)
+    relationship&.destroy 
+  end
+
+  # 現在のユーザーがフォローしてたらtrueを返す
+  def following?(other_user)
+    following.include?(other_user)
+  end
+
   private
 
   def self.generate_username_from_google_name(name, email)
@@ -66,9 +93,9 @@ class User < ApplicationRecord
     base_username = if name.present?
                       # 日本語名の場合は姓名を結合、英語名の場合は最初の名前を使用
                       name.gsub(/\s+/, "").slice(0, 8)
-    else
+                    else
                       email.split("@").first.slice(0, 8)
-    end
+                    end
 
     username = base_username
     counter = 1

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,15 +12,15 @@ class User < ApplicationRecord
   has_many :answers, dependent: :destroy
   has_one :answer_record, dependent: :destroy
 
-  has_many :active_relationships, 
-    class_name: 'Relationship',
-    foreign_key: 'follower_id',
+  has_many :active_relationships,
+    class_name: "Relationship",
+    foreign_key: "follower_id",
     dependent: :destroy
-  has_many :passive_relationships, 
+  has_many :passive_relationships,
     class_name: "Relationship",
     foreign_key: "followed_id",
     dependent: :destroy
-  
+
   has_many :following, through: :active_relationships, source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
 
@@ -78,7 +78,7 @@ class User < ApplicationRecord
 
   def unfollow(other_user)
     relationship = active_relationships.find_by(followed_id: other_user.id)
-    relationship&.destroy 
+    relationship&.destroy
   end
 
   # 現在のユーザーがフォローしてたらtrueを返す
@@ -93,9 +93,9 @@ class User < ApplicationRecord
     base_username = if name.present?
                       # 日本語名の場合は姓名を結合、英語名の場合は最初の名前を使用
                       name.gsub(/\s+/, "").slice(0, 8)
-                    else
+    else
                       email.split("@").first.slice(0, 8)
-                    end
+    end
 
     username = base_username
     counter = 1

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -10,12 +10,34 @@
   <% @posts.each do |post| %>
     <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition duration-150 ease-in-out">
       <div class="flex items-center justify-between mb-4">
-        <div class="text-gray-500">
-          <%= post.user.username %>
-          <span class="mx-2">•</span>
-          <%= l(post.learning_date, format: :short) %>
+        <div class="flex items-center space-x-4">
+          <div class="text-gray-500">
+            <%= post.user.username %>
+            <span class="mx-2">•</span>
+            <%= l(post.learning_date, format: :short) %>
+          </div>
+          
+          <!-- フォローボタン（ログインユーザーと投稿者が異なる場合のみ表示） -->
+          <% if user_signed_in? && current_user != post.user %>
+            <div id="follow_button_<%= post.user.id %>">
+              <% if current_user.following?(post.user) %>
+                <%= button_to "フォロー解除", relationships_path(followed_id: post.user.id),
+                    method: :delete,
+                    data: { turbo_method: :delete },
+                    class: "bg-gray-500 hover:bg-gray-600 text-white py-1 px-2 text-sm rounded",
+                    id: "follow_button_#{post.user.id}" %>
+              <% else %>
+                <%= button_to "フォローする", relationships_path(followed_id: post.user.id),
+                    method: :post,
+                    data: { turbo_method: :post },
+                    class: "bg-blue-500 hover:bg-blue-600 text-white py-1 px-2 text-sm rounded",
+                    id: "follow_button_#{post.user.id}" %>
+              <% end %>
+            </div>
+          <% end %>
         </div>
-            <%= render 'like_button', post: post %>
+        
+        <%= render 'like_button', post: post %>
       </div>
       
       <h3 class="text-xl font-semibold mb-2">

--- a/app/views/relationships/create.turbo_stream.erb
+++ b/app/views/relationships/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "follow_button_#{@user.id}" do %>
+  <%= button_to "フォロー解除", relationships_path(followed_id: @user.id),
+      method: :delete,
+      data: { turbo_method: :delete },
+      class: "bg-gray-500 hover:bg-gray-600 text-white py-1 px-2 text-sm rounded",
+      id: "follow_button_#{@user.id}" %>
+<% end %>

--- a/app/views/relationships/destroy.turbo_stream.erb
+++ b/app/views/relationships/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "follow_button_#{@user.id}" do %>
+  <%= button_to "フォローする", relationships_path(followed_id: @user.id),
+      method: :post,
+      data: { turbo_method: :post },
+      class: "bg-blue-500 hover:bg-blue-600 text-white py-1 px-2 text-sm rounded",
+      id: "follow_button_#{@user.id}" %>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -29,3 +29,4 @@ ja:
       invalid: は不正な値です
       not_a_number: は数値で入力してください
       unauthorized_edit_post: 他のユーザーの投稿は編集できません。
+      not_self_follow: 自分自身をフォローすることはできません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,9 @@ Rails.application.routes.draw do
     resource :like, only: [ :create, :destroy ]
   end
 
-  resources :relationships, only: [:create, :destroy]
-  delete 'relationships', to: 'relationships#destroy'
-  
+  resources :relationships, only: [ :create, :destroy ]
+  delete "relationships", to: "relationships#destroy"
+
   resources :daily_questions, only: [ :index, :show ] do
     resources :answers, only: [ :create ]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     resource :like, only: [ :create, :destroy ]
   end
 
+  resources :relationships, only: [:create, :destroy]
+  delete 'relationships', to: 'relationships#destroy'
+  
   resources :daily_questions, only: [ :index, :show ] do
     resources :answers, only: [ :create ]
   end

--- a/db/migrate/20250526084826_create_relationships.rb
+++ b/db/migrate/20250526084826_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[7.2]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250526090006_add_constraints_to_relationships.rb
+++ b/db/migrate/20250526090006_add_constraints_to_relationships.rb
@@ -1,0 +1,14 @@
+class AddConstraintsToRelationships < ActiveRecord::Migration[7.2]
+  def change
+    # 外部キー制約を追加
+    add_foreign_key :relationships, :users, column: :follower_id
+    add_foreign_key :relationships, :users, column: :followed_id
+    
+    # NOT NULL制約を追加
+    change_column_null :relationships, :follower_id, false
+    change_column_null :relationships, :followed_id, false
+    
+    # 一意性制約を追加（同じペアの重複を防ぐ）
+    add_index :relationships, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/migrate/20250526090006_add_constraints_to_relationships.rb
+++ b/db/migrate/20250526090006_add_constraints_to_relationships.rb
@@ -3,12 +3,12 @@ class AddConstraintsToRelationships < ActiveRecord::Migration[7.2]
     # 外部キー制約を追加
     add_foreign_key :relationships, :users, column: :follower_id
     add_foreign_key :relationships, :users, column: :followed_id
-    
+
     # NOT NULL制約を追加
     change_column_null :relationships, :follower_id, false
     change_column_null :relationships, :followed_id, false
-    
+
     # 一意性制約を追加（同じペアの重複を防ぐ）
-    add_index :relationships, [:follower_id, :followed_id], unique: true
+    add_index :relationships, [ :follower_id, :followed_id ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_26_074906) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_26_090006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -102,6 +102,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_26_074906) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id", null: false
+    t.integer "followed_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -128,4 +136,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_26_074906) do
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"
+  add_foreign_key "relationships", "users", column: "followed_id"
+  add_foreign_key "relationships", "users", column: "follower_id"
 end

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :relationship do
+    follower_id { 1 }
+    followed_id { 1 }
+  end
+end

--- a/spec/helpers/relationships_helper_spec.rb
+++ b/spec/helpers/relationships_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RelationshipsHelper. For example:
+#
+# describe RelationshipsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RelationshipsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/relationships_spec.rb
+++ b/spec/requests/relationships_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Relationships", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
ユーザー同士がフォロー/フォロー解除できる機能を実装

## 実装内容
### 1. モデル層
- **Relationshipモデルの作成**
  - ユーザー間のフォロー関係を管理
  - 自分自身のフォロー防止バリデーション
  - 重複フォロー防止の一意性制約

- **Userモデルの拡張**
  - `active_relationships` / `passive_relationships` アソシエーション追加
  - `following` / `followers` 多対多関係の定義
  - `follow(user)` / `unfollow(user)` / `following?(user)` メソッド追加

### 2. コントローラー層
- **RelationshipsController の作成**
  - `create` アクション：フォロー処理
  - `destroy` アクション：フォロー解除処理
  - Ajax対応（Turbo Stream レスポンス）

- **PostsController の修正**
  - `show` アクションに `@user = @post.user` を追加

### 3. ビュー層
- **フォローボタンの実装**
  - `posts/index.html.erb`：投稿一覧画面にフォローボタン追加
  - `posts/show.html.erb`：投稿詳細画面にフォローボタン追加
  - Ajax対応でページ遷移なしでの操作が可能

- **Turbo Stream ビューの作成**
  - `relationships/create.turbo_stream.erb`
  - `relationships/destroy.turbo_stream.erb`

### 4. データベース
- **relationshipsテーブルの作成**
  ```sql
  create_table :relationships do |t|
    t.integer :follower_id
    t.integer :followed_id
    t.timestamps
  end
  ```

- **制約の追加**
  - 外部キー制約
  - NOT NULL制約
  - 一意性制約（同じペアの重複防止）

### 5. ルーティング
```ruby
resources :relationships, only: [:create]
delete 'relationships', to: 'relationships#destroy'
```

## 主な機能
- ✅ ユーザーをフォロー/フォロー解除
- ✅ 自分自身のフォロー防止
- ✅ 重複フォローの防止
- ✅ Ajax対応（ページ遷移なし）
- ✅ 投稿一覧・詳細画面でのフォローボタン表示