### PR TITLE
OGPとXシェアの設定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta property="og:site_name" content="Better than yesterday">
+    <meta property="og:type" content="<%= content_for?(:og_type) ? yield(:og_type) : 'website' %>">
+    <meta property="og:title" content="<%= content_for?(:og_title) ? yield(:og_title) : (content_for?(:title) ? yield(:title) : 'Better than yesterday') %>">
+    <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : '昨日の自分より少しだけ成長する学習記録・共有プラットフォーム' %>">
+    <meta property="og:url" content="<%= content_for?(:og_url) ? yield(:og_url) : request.original_url %>">
+    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : asset_url('header_logo.png') %>">
+
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@your_twitter_account">
+
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,12 @@
+<% content_for :title, @post.title %>
+<% content_for :og_type, "article" %>
+<% content_for :og_title, "#{@post.title} - #{@post.user.username}の学習記録" %>
+<% content_for :og_description, truncate(@post.body, length: 100) %>
+<% content_for :og_url, post_url(@post) %>
+<% if @post.image.attached? %>
+  <% content_for :og_image, url_for(@post.image) %>
+<% end %>
+
 <div class="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-md my-6">
   <h1 class="text-2xl font-bold text-center mb-6">学びの振り返り詳細</h1>
 
@@ -60,6 +69,21 @@
       </div>
     </div>
   </div>
+
+  <div class="mt-6 text-center">
+  <%= link_to "https://twitter.com/intent/tweet?text=#{CGI.escape("#{@post.title} - #{@post.user.username}の学習記録")}&url=#{CGI.escape(post_url(@post))}&hashtags=BetterThanYesterday,学習記録",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      class: "inline-flex items-center justify-center gap-2 px-5 py-2 bg-black hover:bg-gray-800 text-white font-semibold rounded-full shadow-md transition-transform duration-200 hover:scale-105" do %>
+    
+    <svg class="w-5 h-5 fill-current" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+    </svg>
+
+    <span>この投稿をシェア</span>
+  <% end %>
+</div>
+
 
   <% if user_signed_in? && current_user == @post.user %>
     <div class="flex space-x-4">


### PR DESCRIPTION
## 📝 概要
投稿詳細ページにX（旧Twitter）共有機能と静的OGPを実装

## ✨ 実装内容

### 1. 静的OGP（Open Graph Protocol）の実装
- **基本OGPメタタグの追加** (`app/views/layouts/application.html.erb`)
  - `og:site_name`: サイト名
  - `og:type`: コンテンツタイプ（投稿詳細では"article"）
  - `og:title`: ページタイトル
  - `og:description`: ページ説明
  - `og:url`: ページURL
  - `og:image`: OGP画像（投稿画像 or デフォルト画像）

- **Twitter Card対応**
  - `twitter:card`: summary_large_image
  - `twitter:site`: Twitterアカウント（オプション）

- **投稿個別のOGP設定** (`app/views/posts/show.html.erb`)
  - 投稿タイトルと投稿者名を組み合わせたタイトル
  - 投稿本文の最初の100文字を説明文として使用
  - 投稿に画像が添付されている場合はその画像を使用
  - 投稿の正確なURLを設定

### 2. X（Twitter）共有機能の実装
- **共有ボタンの追加** (`app/views/posts/show.html.erb`)
  - 投稿詳細ページの「今日の一問」セクション下に配置
  - X公式のブランドカラー（黒）を使用
  - ホバーエフェクトとスケールアニメーション
  - 新しいXロゴのSVGアイコン

### OGP画像の仕様
- **デフォルト画像**: `app/assets/images/header_logo.png`
- **個別投稿**: 投稿に画像が添付されている場合はその画像を使用
