### PR TITLE
Question type

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,5 +22,8 @@ application.register("image-preview", ImagePreviewController)
 import QuestionGeneratorController from "./question_generator_controller"
 application.register("question-generator", QuestionGeneratorController)
 
+import QuestionTypeSwitcherController from "./question_type_switcher_controller"
+application.register("question-type-switcher", QuestionTypeSwitcherController)
+
 import ToggleController from "./toggle_controller"
 application.register("toggle", ToggleController)

--- a/app/javascript/controllers/question_type_switcher_controller.js
+++ b/app/javascript/controllers/question_type_switcher_controller.js
@@ -1,0 +1,67 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["selector", "template", "bodyField", "answerField"]
+
+  connect() {
+    this.switchTemplate()
+  }
+
+  switchTemplate() {
+    const selectedType = this.selectorTarget.value
+    this.updateTemplate(selectedType)
+    this.updatePlaceholders(selectedType)
+  }
+
+  updateTemplate(type) {
+    const templates = {
+      description: `
+        <strong>📝 記述式問題のテンプレート：</strong><br>
+        「〜について説明してください」<br>
+        「〜の理由を述べてください」<br>
+        「〜と〜の違いは何ですか？」
+      `,
+      multiple_choice: `
+        <strong>📋 選択式問題のテンプレート：</strong><br>
+        問題文<br>
+        A) 選択肢1<br>
+        B) 選択肢2<br>
+        C) 選択肢3<br>
+        D) 選択肢4
+      `,
+      fill_in_blank: `
+        <strong>📝 穴埋め式問題のテンプレート：</strong><br>
+        「〜は【　　　】である」<br>
+        「〜の手順は【　　　】→【　　　】→【　　　】である」
+      `
+    }
+
+    this.templateTarget.innerHTML = templates[type] || ""
+  }
+
+  updatePlaceholders(type) {
+    const placeholders = {
+      description: {
+        body: "例：Railsのactive_recordパターンについて説明してください。",
+        answer: "例：active_recordパターンとは、データベースのテーブルの1行をオブジェクトで表現し..."
+      },
+      multiple_choice: {
+        body: "例：次のうち、Railsの命名規則として正しいのはどれ？\nA) モデル名は複数形\nB) テーブル名は単数形\nC) コントローラー名は単数形\nD) モデル名は単数形",
+        answer: "例：D"
+      },
+      fill_in_blank: {
+        body: "例：Railsでデータベースから全てのユーザーを取得するには【　　　】メソッドを使用する。",
+        answer: "例：User.all"
+      }
+    }
+
+    const placeholder = placeholders[type] || placeholders.description
+    
+    if (this.hasBodyFieldTarget) {
+      this.bodyFieldTarget.placeholder = placeholder.body
+    }
+    if (this.hasAnswerFieldTarget) {
+      this.answerFieldTarget.placeholder = placeholder.answer
+    }
+  }
+}

--- a/app/models/daily_question.rb
+++ b/app/models/daily_question.rb
@@ -6,6 +6,12 @@ class DailyQuestion < ApplicationRecord
   has_many :answers, dependent: :destroy
   has_many :answered_users, through: :answers, source: :user
 
+  enum question_type: {
+    description: 0,     # 記述式
+    multiple_choice: 1, # 選択式
+    fill_in_blank: 2    # 穴埋め式
+  }
+
   # この問題の正答率
   def correct_rate
     return 0.0 if answers.count == 0
@@ -21,4 +27,16 @@ class DailyQuestion < ApplicationRecord
   def user_answer(user)
     answers.find_by(user: user)
   end
+
+  def question_type_name
+    case question_type
+    when 'description'
+      '記述式'
+    when 'multiple_choice'
+      '選択式'
+    when 'fill_in_blank'
+      '穴埋め式'
+    end
+  end
+  
 end

--- a/app/models/daily_question.rb
+++ b/app/models/daily_question.rb
@@ -30,13 +30,12 @@ class DailyQuestion < ApplicationRecord
 
   def question_type_name
     case question_type
-    when 'description'
-      '記述式'
-    when 'multiple_choice'
-      '選択式'
-    when 'fill_in_blank'
-      '穴埋め式'
+    when "description"
+      "記述式"
+    when "multiple_choice"
+      "選択式"
+    when "fill_in_blank"
+      "穴埋め式"
     end
   end
-  
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -7,18 +7,19 @@
     <%= form_with(model: @post, local: true, class: "space-y-4") do |f| %>
       <div>
         <%= f.label :learning_date, class: 'block text-sm font-medium text-gray-700' %>
-        <%= f.date_field :learning_date, value: Date.today, class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
+        <%= f.date_field :learning_date, value: Date.today,
+          class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500' %>
       </div>
 
       <div data-controller="character-counter">
         <%= f.label :title, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_field :title,
-              class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500',
-              maxlength: 20,
-              data: {
-                character_counter_target: "field",
-                action: "input->character-counter#updateCounter"
-              } %>
+          class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500',
+          maxlength: 20,
+          data: {
+            character_counter_target: "field",
+            action: "input->character-counter#updateCounter"
+          } %>
         <div class="text-right text-xs text-gray-500 mt-1">
           <span data-character-counter-target="counter"><%= @post.title ? @post.title.length : 0 %></span>/20字
         </div>
@@ -27,13 +28,13 @@
       <div data-controller="character-counter">
         <%= f.label :body, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_area :body,
-              class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500',
-              rows: '10',
-              maxlength: 400,
-              data: {
-                character_counter_target: "field",
-                action: "input->character-counter#updateCounter"
-              } %>
+          class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500',
+          rows: 10,
+          maxlength: 400,
+          data: {
+            character_counter_target: "field",
+            action: "input->character-counter#updateCounter"
+          } %>
         <div class="text-right text-xs text-gray-500 mt-1">
           <span data-character-counter-target="counter"><%= @post.body ? @post.body.length : 0 %></span>/400字
         </div>
@@ -41,15 +42,14 @@
 
       <div data-controller="character-counter">
         <%= f.label :tag_names, "タグ（カンマ区切り）", class: 'block text-sm font-medium text-gray-700' %>
-        <%= f.text_field :tag_names, 
-              value: @post.tag_names,
-              class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500',
-              placeholder: "Rails,プログラミング,学習記録",
-              data: {
-                character_counter_target: "field",
-                action: "input->character-counter#updateCounter"
-              }
-        %>
+        <%= f.text_field :tag_names,
+          value: @post.tag_names,
+          class: 'mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500',
+          placeholder: "Rails,プログラミング,学習記録",
+          data: {
+            character_counter_target: "field",
+            action: "input->character-counter#updateCounter"
+          } %>
         <div class="text-xs text-gray-500 mt-1">
           <div class="text-right">
             <span data-character-counter-target="counter"><%= @post.tag_names ? @post.tag_names.length : 0 %></span>字
@@ -60,9 +60,9 @@
       <div class="mb-4" data-controller="image-preview">
         <%= f.label :image, "画像", class: "block text-gray-700 text-sm font-bold mb-2" %>
         <%= f.file_field :image,
-              class: "w-full",
-              accept: "image/jpeg,image/png,image",
-              data: { image_preview_target: "input", action: "change->image-preview#previewImage" } %>
+          class: "w-full",
+          accept: "image/jpeg,image/png,image",
+          data: { image_preview_target: "input", action: "change->image-preview#previewImage" } %>
 
         <% if f.object.image.attached? %>
           <div class="mt-2" data-image-preview-target="preview">
@@ -76,49 +76,75 @@
       <div class="mt-8 mb-4">
         <h2 class="text-xl font-bold mb-4">今日の一問</h2>
 
-        <div data-controller="question-generator">
+        <div data-controller="question-generator question-type-switcher">
           <%= f.fields_for :daily_question do |question_form| %>
+            <!-- 問題タイプ選択 -->
+            <div class="mb-6 max-w-xs">
+              <%= question_form.label :question_type, "問題タイプ", class: "block text-sm font-medium text-gray-700 mb-2" %>
+              <%= question_form.select :question_type,
+                options_for_select([
+                  ['記述式', 'description'],
+                  ['選択式', 'multiple_choice'],
+                  ['穴埋め式', 'fill_in_blank']
+                ], @post.daily_question&.question_type || 'description'),
+                {},
+                {
+                  class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 bg-white",
+                  data: {
+                    question_type_switcher_target: "selector",
+                    action: "change->question-type-switcher#switchTemplate"
+                  }
+                } %>
+            </div>
+
+            <!-- テンプレート表示エリア -->
+            <div data-question-type-switcher-target="template" class="mb-4 p-3 bg-gray-50 border rounded-md text-sm text-gray-600">
+              <!-- JavaScript で動的に更新される -->
+            </div>
+
+            <!-- 問題文 -->
             <div class="mb-4" data-controller="character-counter">
-              <%= question_form.label :body, class: "block mb-2" %>
+              <%= question_form.label :body, "問題文", class: "block mb-2" %>
               <%= question_form.text_area :body,
-                  rows: 6,
-                  class: "w-full p-2 border rounded",
-                  placeholder: "次のうち、正しいのはどれ？\nA)○○\nB)○○\nC)○○",
-                  maxlength: 400,
-                  data: {
-                    character_counter_target: "field",
-                    action: "input->character-counter#updateCounter"
-                  } %>
+                rows: 6,
+                class: "w-full p-2 border rounded",
+                maxlength: 400,
+                data: {
+                  character_counter_target: "field",
+                  action: "input->character-counter#updateCounter",
+                  question_type_switcher_target: "bodyField"
+                } %>
 
-            <button type="button"
-                    class="mt-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded text-sm"
-                    data-action="click->question-generator#generateQuestion"
-                    data-question-generator-target="generateButton">
-              AIで問題を自動生成
-            </button>
+              <button type="button"
+                class="mt-2 bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-3 rounded text-sm"
+                data-action="click->question-generator#generateQuestion"
+                data-question-generator-target="generateButton">
+                AIで問題を自動生成
+              </button>
 
-            <span data-question-generator-target="status" class="ml-2 text-sm text-gray-600"></span>
-            <div class="text-right text-xs text-gray-500 mt-1">
-              <span data-character-counter-target="counter"><%= @post.daily_question&.body ? @post.daily_question.body.length : 0 %></span>/400字
+              <span data-question-generator-target="status" class="ml-2 text-sm text-gray-600"></span>
+              <div class="text-right text-xs text-gray-500 mt-1">
+                <span data-character-counter-target="counter"><%= @post.daily_question&.body ? @post.daily_question.body.length : 0 %></span>/400字
+              </div>
             </div>
-          </div>
 
-          <div class="mb-4" data-controller="character-counter">
-            <%= question_form.label :question_answer, class: "block mb-2" %>
-            <%= question_form.text_field :question_answer,
-                  class: "w-full p-2 border rounded",
-                  placeholder: "A",
-                  maxlength: 400,
-                  data: {
-                    character_counter_target: "field",
-                    action: "input->character-counter#updateCounter"
-                  } %>
-
-            <div class="text-right text-xs text-gray-500 mt-1">
-              <span data-character-counter-target="counter"><%= @post.daily_question&.question_answer ? @post.daily_question.question_answer.length : 0 %></span>/400字
+            <!-- 解答 -->
+            <div class="mb-4" data-controller="character-counter">
+              <%= question_form.label :question_answer, "解答", class: "block mb-2" %>
+              <%= question_form.text_field :question_answer,
+                class: "w-full p-2 border rounded",
+                maxlength: 400,
+                data: {
+                  character_counter_target: "field",
+                  action: "input->character-counter#updateCounter",
+                  question_type_switcher_target: "answerField"
+                } %>
+              <div class="text-right text-xs text-gray-500 mt-1">
+                <span data-character-counter-target="counter"><%= @post.daily_question&.question_answer ? @post.daily_question.question_answer.length : 0 %></span>/400字
+              </div>
             </div>
-          </div>
-        <% end %>
+          <% end %>
+        </div>
       </div>
 
       <div>


### PR DESCRIPTION


## 📝 概要
DailyQuestionモデルにenumで問題タイプを追加し、投稿作成時に問題タイプに応じたテンプレートを動的表示する機能を実装

## ✨ 実装内容

### 1. DailyQuestionモデルにenum追加
```ruby
enum question_type: {
  description: 0,     # 記述式
  multiple_choice: 1, # 選択式  
  fill_in_blank: 2    # 穴埋め式
}
```

### 2. 投稿作成フォームの改善
- 問題タイプ選択ドロップダウンの追加
- 選択に応じたテンプレート表示エリアの実装
- 各問題タイプ別のプレースホルダー設定

### 3. Stimulusコントローラーの追加
- `question_type_switcher_controller.js` を新規作成
- 問題タイプ変更時の動的テンプレート切り替え機能


## 🎯 機能詳細

### 問題タイプ別テンプレート
- **記述式**: 「〜について説明してください」形式
- **選択式**: A)B)C)D)の選択肢形式  
- **穴埋め式**: 【　　　】を使った穴埋め形式
